### PR TITLE
Point Mac modulemap to the SDK that ships with Xcode 7 GM seed

### DIFF
--- a/CommonCrypto/macosx.modulemap
+++ b/CommonCrypto/macosx.modulemap
@@ -1,4 +1,4 @@
 module CommonCrypto [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }


### PR DESCRIPTION
This pull request updated the `macosx.modulemap` point to the `MacOSX10.11.sdk` inside of the Xcode 7 GM seed since `MacOSX10.10.sdk` is not included.

I'm not entirely sure that this is the right thing to do or even the right way to go about this but figured it was easier to make the change and discuss from there.
